### PR TITLE
Fix routes import and main router usage

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -19,7 +19,7 @@ import '../presentation/screens/progress/progress_screen.dart';
 import '../presentation/screens/profile/profile_screen.dart';
 import '../presentation/screens/settings/settings_screen.dart';
 import '../presentation/providers/auth_provider.dart';
-import '../presentation/screens/profile/history_screen.dart' as history_screen;
+import '../presentation/screens/profile/history_screen.dart';
 
 // Route Constants
 class _Routes {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,6 +63,7 @@ class SkinSenseApp extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final authState = ref.watch(authStateProvider);
     final settings = ref.watch(settingsProvider);
+    final router = ref.watch(routerProvider);
 
     return MaterialApp.router(
       title: 'SkinSense',


### PR DESCRIPTION
## Summary
- fix import alias in routes.dart so `HistoryScreen` resolves correctly
- use `routerProvider` in `main.dart`

## Testing
- `dart format lib/config/routes.dart lib/main.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872d927df0083269c36aeab0afa4385